### PR TITLE
+ static files exposed for e2e tests

### DIFF
--- a/My1kWordsEe.Tests.E2E/Infra/BlazorTest.cs
+++ b/My1kWordsEe.Tests.E2E/Infra/BlazorTest.cs
@@ -16,7 +16,15 @@ public class BlazorTest : PageTest
     [SetUp]
     public async Task SetUpWebApplication()
     {
-        _host = Program.BuildWebHost(new string[] { });
+        var executionDir = Path.GetDirectoryName(typeof(BlazorTest).Assembly.Location)!;
+        var webRootPath = Path.Combine(executionDir, "../../../../My1kWordsEe/wwwroot");
+        var args = new[] 
+        { 
+            $"--webroot={Path.GetFullPath(webRootPath)}",
+            "--environment=Development",
+            "--applicationName=My1kWordsEe"
+        };
+        _host = Program.BuildWebHost(args);
 
         await _host.StartAsync();
 

--- a/My1kWordsEe/Components/App.razor
+++ b/My1kWordsEe/Components/App.razor
@@ -26,6 +26,7 @@
         crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script src="_content/Blazor.Bootstrap/blazor.bootstrap.js"></script>
+    <script src="_content/Blazor.Bootstrap/blazor.bootstrap.theme-switcher.js"></script>
 </body>
 
 </html>

--- a/My1kWordsEe/wwwroot/blazor.bootstrap.theme-switcher.js
+++ b/My1kWordsEe/wwwroot/blazor.bootstrap.theme-switcher.js
@@ -1,0 +1,82 @@
+// THEMES
+const STORAGE_KEY = "blazorbootstrap-theme";
+const DEFAULT_THEME = "light";
+const LIGHT_THEME = "light";
+const DARK_THEME = "dark";
+const SYSTEM_THEME = "system";
+
+const state = {
+    chosenTheme: SYSTEM_THEME, // light|dark|system
+    appliedTheme: DEFAULT_THEME // light|dark
+};
+
+const showActiveTheme = () => {
+    let themeIndicatorEls = document.querySelectorAll(".blazorbootstrap-theme-indicator>i");
+    if (themeIndicatorEls.length > 0) {
+        themeIndicatorEls.forEach((el, index) => {
+            if (state.chosenTheme === SYSTEM_THEME
+                && state.chosenTheme !== state.appliedTheme) {
+                el.className = "bi bi-circle-half";
+            }
+            else if (state.appliedTheme === LIGHT_THEME) {
+                el.className = "bi bi-sun-fill";
+            } else if (state.appliedTheme === DARK_THEME) {
+                el.className = "bi bi-moon-stars-fill";
+            } else {
+                el.className = "bi bi-circle-half";
+            }
+        });
+    }
+
+    let themeSwitcherItemEls = document.querySelectorAll(".blazorbootstrap-theme-item>button");
+    if (themeSwitcherItemEls) {
+        themeSwitcherItemEls.forEach((el) => {
+            const bsThemeValue = el.dataset.bsThemeValue;
+            const iEl = el.querySelector(".bi.bi-check2");
+            if (state.chosenTheme === bsThemeValue) {
+                el.classList.add("active");
+                if (iEl)
+                    iEl.classList.remove("d-none");
+            } else {
+                el.classList.remove("active");
+                if (iEl)
+                    iEl.classList.add("d-none");
+            }
+        });
+    }
+};
+
+export function setTheme(dotNetHelper, theme, save = true) {
+    state.chosenTheme = theme;
+    state.appliedTheme = theme;
+
+    if (theme === SYSTEM_THEME) {
+        state.appliedTheme = window.matchMedia(`(prefers-color-scheme: ${DARK_THEME})`).matches ? DARK_THEME : LIGHT_THEME;
+    }
+
+    document.documentElement.setAttribute("data-bs-theme", state.appliedTheme);
+    if (save) {
+        window.localStorage.setItem(STORAGE_KEY, state.chosenTheme);
+    }
+    showActiveTheme();
+    if (dotNetHelper)
+        dotNetHelper.invokeMethodAsync("OnThemeChangedJS", state.appliedTheme);
+};
+
+export function initializeTheme(dotNetHelper) {
+    const localTheme = window.localStorage.getItem(STORAGE_KEY);
+    if (localTheme) {
+        setTheme(dotNetHelper, localTheme, false);
+    } else {
+        setTheme(dotNetHelper, SYSTEM_THEME);
+    }
+
+    // register events
+    window
+        .matchMedia(`(prefers-color-scheme: ${DARK_THEME})`)
+        .addEventListener("change", (event) => {
+            //const theme = event.matches ? DARK_THEME : LIGHT_THEME;
+            //setTheme(theme);
+            setTheme(dotNetHelper, SYSTEM_THEME);
+        });
+}


### PR DESCRIPTION
The "WebRootPath was not found" warning and the associated test failures have been resolved.

  The issue was caused by the test execution environment (running from the bin directory) not correctly
  locating the web project's static assets and configuration. I updated Infra/BlazorTest.cs to
  explicitly configure the web host during test setup.

  Changes made in `Infra/BlazorTest.cs`:
  Updated SetUpWebApplication to pass the following arguments to Program.BuildWebHost:
   1. --webroot={PathToSourceWwwroot}: Explicitly points to the source My1kWordsEe/wwwroot directory,
      ensuring UseStaticFiles can serve physical files like app.css. This resolved the "WebRootPath not
      found" warning.
   2. --environment=Development: Forces the Development environment, enabling the loading of the Static
      Web Assets manifest.
   3. --applicationName=My1kWordsEe: Sets the application name to My1kWordsEe. This is critical for the
      host to locate the correct My1kWordsEe.staticwebassets.runtime.json manifest file in the output
      directory, ensuring assets from libraries like Blazor.Bootstrap are served correctly.

  Verification:
  Ran dotnet test and confirmed that:
   * The "WebRootPath was not found" warning is gone.
   * The static asset 404 errors (for Blazor.Bootstrap) are resolved.
   * All tests passed successfully (Failed: 0, Passed: 3).